### PR TITLE
feat(mailer): add mailer service to broker and set names to routes

### DIFF
--- a/micro-services/authentication-service/cmd/api/main.go
+++ b/micro-services/authentication-service/cmd/api/main.go
@@ -26,7 +26,7 @@ func main() {
 	service := services.NewUserService(repo)
 	handlers := handlers.NewAuthHandler(service)
 
-	router.POST("/v1/authenticate", handlers.Authenticate)
+	routes.SetRoutes(router, handlers)
 
 	router.Run(":80")
 }

--- a/micro-services/authentication-service/routes/routes.go
+++ b/micro-services/authentication-service/routes/routes.go
@@ -1,1 +1,21 @@
 package routes
+
+import (
+	"auth/handlers"
+
+	"github.com/gin-gonic/gin"
+)
+
+func SetRoutes(g *gin.Engine, h handlers.AuthenticationHandlerInterface) *gin.RouterGroup {
+
+	v1 := g.Group("/v1")
+	publicRoutes(v1, h)
+	return v1
+}
+
+func publicRoutes(g *gin.RouterGroup, h handlers.AuthenticationHandlerInterface) {
+	g.Group("/")
+	{
+		g.POST("/auth", h.Authenticate)
+	}
+}

--- a/micro-services/broker-service/cmd/api/main.go
+++ b/micro-services/broker-service/cmd/api/main.go
@@ -16,7 +16,7 @@ func main() {
 	s := services.NewBrokerService()
 	h := handlers.NewBrokerHandler(s)
 
-	router.RouterGroup = *routes.SetRoutes(router, h)
+	routes.SetRoutes(router, h)
 
 	router.Run(":80")
 }

--- a/micro-services/broker-service/handlers/handlers.go
+++ b/micro-services/broker-service/handlers/handlers.go
@@ -38,6 +38,8 @@ func (h *brokerHandler) SubmissionHandler(c *gin.Context) {
 		h.Authenticate(request.Auth, c)
 	case "log":
 		h.Log(request.Log)
+	case "mail":
+		h.Mail(request.Mail)
 	}
 }
 
@@ -45,7 +47,7 @@ func (h *brokerHandler) Authenticate(req models.AuthPayload, c *gin.Context) {
 	jsonData, _ := json.Marshal(req)
 	var logData models.LogEntry
 
-	request, err := http.NewRequest("POST", "http://auth-service/v1/authenticate", bytes.NewBuffer(jsonData))
+	request, err := http.NewRequest("POST", "http://auth-service/v1/auth", bytes.NewBuffer(jsonData))
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": err.Error(),
@@ -85,7 +87,7 @@ func (h *brokerHandler) Authenticate(req models.AuthPayload, c *gin.Context) {
 
 func (h *brokerHandler) Log(req models.LogEntry) {
 	jsonData, _ := json.Marshal(req)
-	request, err := http.NewRequest("POST", "http://logger-service/public/logs/new", bytes.NewBuffer(jsonData))
+	request, err := http.NewRequest("POST", "http://logger-service/v1/logs/new", bytes.NewBuffer(jsonData))
 	if err != nil {
 		fmt.Printf("err.Error(): %v\n", err.Error())
 		return
@@ -99,4 +101,22 @@ func (h *brokerHandler) Log(req models.LogEntry) {
 	}
 
 	fmt.Printf("res: %v\n", res.StatusCode)
+}
+
+func (h *brokerHandler) Mail(payload models.MailPayload) {
+	jsonData, _ := json.Marshal(payload)
+	request, err := http.NewRequest("POST", "http://mail-service/v1/mail", bytes.NewBuffer(jsonData))
+	if err != nil {
+		fmt.Printf("err.Error(): %v\n", err.Error())
+		return
+	}
+
+	client := http.Client{}
+	res, err := client.Do(request)
+	if err != nil {
+		fmt.Printf("err: %v\n", err.Error())
+		return
+	}
+
+	fmt.Printf("res.StatusCode: %v\n", res.StatusCode)
 }

--- a/micro-services/broker-service/models/models.go
+++ b/micro-services/broker-service/models/models.go
@@ -4,6 +4,7 @@ type RequestPayload struct {
 	Action string      `json:"action"`
 	Auth   AuthPayload `json:"auth,omitempty"`
 	Log    LogEntry    `json:"log,omitempty"`
+	Mail   MailPayload `json:"mail,omitempty"`
 }
 
 type AuthPayload struct {
@@ -14,4 +15,11 @@ type AuthPayload struct {
 type LogEntry struct {
 	Name string `json:"name"`
 	Data string `json:"data"`
+}
+
+type MailPayload struct {
+	From    string `json:"from"`
+	To      string `json:"to"`
+	Subject string `json:"subject"`
+	Message string `json:"message"`
 }

--- a/micro-services/broker-service/routes/routes.go
+++ b/micro-services/broker-service/routes/routes.go
@@ -9,16 +9,14 @@ import (
 func SetRoutes(g *gin.Engine, h handlers.BrokerHandlerInterface) *gin.RouterGroup {
 
 	v1 := g.Group("/v1")
-	{
-		public(g, h)
-	}
+	publicRoutes(v1, h)
 	return v1
 }
 
-func public(g *gin.Engine, h handlers.BrokerHandlerInterface) *gin.RouterGroup {
-	pbRoutes := g.Group("/public")
+func publicRoutes(g *gin.RouterGroup, h handlers.BrokerHandlerInterface) {
+	g.Group("/")
 	{
-		pbRoutes.POST("/auth", h.SubmissionHandler)
+		g.POST("/auth-service", h.SubmissionHandler)
+		g.POST("/send", h.SubmissionHandler)
 	}
-	return pbRoutes
 }

--- a/micro-services/logger-service/cmd/api/main.go
+++ b/micro-services/logger-service/cmd/api/main.go
@@ -33,7 +33,7 @@ func main() {
 	s := services.NewLoggerServices(r)
 	h := handlers.NewLoggerHandlers(s)
 
-	router.RouterGroup = *routes.SetRoutes(router, h)
+	routes.SetRoutes(router, h)
 
 	router.Run(newConf.InternalPort)
 

--- a/micro-services/logger-service/routes/routes.go
+++ b/micro-services/logger-service/routes/routes.go
@@ -8,19 +8,16 @@ import (
 
 func SetRoutes(g *gin.Engine, h handlers.LoggerHandInterface) *gin.RouterGroup {
 	v1 := g.Group("/v1")
-	{
-		public(g, h)
-	}
+	publicRoutes(v1, h)
 	return v1
 }
 
-func public(g *gin.Engine, h handlers.LoggerHandInterface) *gin.RouterGroup {
-	pbGroup := g.Group("/public")
+func publicRoutes(g *gin.RouterGroup, h handlers.LoggerHandInterface) {
+	g.Group("/")
 	{
-		pbGroup.GET("/index", h.All)
-		pbGroup.GET("/logs/:id", h.GetById)
-		pbGroup.POST("/logs/new", h.Insert)
-		pbGroup.DELETE("/logs/delete/all", h.DropCollection)
+		g.GET("/index", h.All)
+		g.GET("/logs/:id", h.GetById)
+		g.POST("/logs/new", h.Insert)
+		g.DELETE("/logs/delete/all", h.DropCollection)
 	}
-	return pbGroup
 }

--- a/micro-services/mail-service/cmd/api/main.go
+++ b/micro-services/mail-service/cmd/api/main.go
@@ -5,6 +5,7 @@ import (
 	"mail-service/handlers"
 	"mail-service/mailer"
 	"mail-service/models"
+	"mail-service/routes"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -30,9 +31,7 @@ func main() {
 	s := mailer.NewMailer(mail)
 	h := handlers.NewMailHandler(s)
 
-	router.POST("/send", h.SendMail)
-	router.POST("/gomail", h.GoMail)
+	routes.SetRoutes(router, h)
 
 	router.Run(conf.WebPort)
-
 }

--- a/micro-services/mail-service/handlers/handlers.go
+++ b/micro-services/mail-service/handlers/handlers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type MailHandler interface {
+type MailHandlerInterface interface {
 	SendMail(*gin.Context)
 	GoMail(*gin.Context)
 }
@@ -17,7 +17,7 @@ type mailHandler struct {
 	mailer mailer.MailerInterface
 }
 
-func NewMailHandler(m mailer.MailerInterface) MailHandler {
+func NewMailHandler(m mailer.MailerInterface) MailHandlerInterface {
 	return &mailHandler{m}
 }
 

--- a/micro-services/mail-service/mailer/mailer.go
+++ b/micro-services/mail-service/mailer/mailer.go
@@ -85,7 +85,6 @@ func (m *mailer) SendGoMail(mailData models.Message) error {
 	// msg.Attach("/home/User/cat.jpg")
 
 	n := gomail.NewDialer(m.mail.Host, m.mail.Port, m.mail.Username, m.mail.Password)
-	// n := gomail.NewDialer("mailhog", 1025, "", "")
 
 	// Send the email
 	if err := n.DialAndSend(msg); err != nil {

--- a/micro-services/mail-service/routes/routes.go
+++ b/micro-services/mail-service/routes/routes.go
@@ -1,0 +1,20 @@
+package routes
+
+import (
+	"mail-service/handlers"
+
+	"github.com/gin-gonic/gin"
+)
+
+func SetRoutes(g *gin.Engine, h handlers.MailHandlerInterface) *gin.RouterGroup {
+	v1 := g.Group("/v1")
+	publicRoutes(v1, h)
+	return v1
+}
+
+func publicRoutes(g *gin.RouterGroup, h handlers.MailHandlerInterface) {
+	g.Group("/")
+	{
+		g.POST("/mail", h.GoMail)
+	}
+}

--- a/micro-services/mail-service/templates/mail.html
+++ b/micro-services/mail-service/templates/mail.html
@@ -361,11 +361,8 @@
                   >
                     <tr>
                       <td>
-                        <p>Hola!</p>
-                        <p>
-                          Si eres una cucarasita muuuy apestosita porfavor dar
-                          click aqui!
-                        </p>
+                        <p>Hello!</p>
+                        <p>Just click here</p>
                         <table
                           role="presentation"
                           border="0"
@@ -388,7 +385,7 @@
                                         <a
                                           href="https://i.pinimg.com/originals/eb/7a/dc/eb7adc437316ecb2ff9bb648f91b0b87.png"
                                           target="_blank"
-                                          >Cucarasita here!</a
+                                          >here!</a
                                         >
                                       </td>
                                     </tr>
@@ -398,7 +395,7 @@
                             </tr>
                           </tbody>
                         </table>
-                        <p>Gracias por su atencion</p>
+                        <p>Thanks! :)</p>
                       </td>
                     </tr>
                   </table>


### PR DESCRIPTION
# Mailer service
- Added mailer to broker
- Set names to routes so they all follow the same v# convention

## To send mail from broker:
``` 
{ "action": "mail",
    "mail": 
      {
          "from": "gabriel@email.com",
          "to": "mailhog@email.com",
          "subject": "test from broker",
          "message": ""
      }
}
```
:warning: 
- Remeber to set the config.yml
- For mailhog:
```
webPort : ":80"
mailDomain: localhost
mailHost: mailhog
mailPort: "1025"
userName: ""
password: ""
encryption: none
fromName: "some-name"
fromAddress: example@mail.com
```